### PR TITLE
Add below-suggested-topics plugin outlet

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -21,6 +21,8 @@
     </div>
   
     <h3 class="suggested-topics-message">{{{browseMoreMessage}}}</h3>
+    
+    {{plugin-outlet name="below-suggested-topics" tagName="span" connectorTagName="div" args=(hash topic=topic)}}
   </script>
 
   <!-----------------


### PR DESCRIPTION
Hi! My name is Chris and I'm on the Reach team at Codecademy. I recently added a new Discourse theme component (`Codecademy Related Content`) to all of the user-selectable themes. The component renders correctly on the base Codecademy theme as below:

<img width="1189" alt="Screen Shot 2022-02-17 at 12 28 56 PM" src="https://user-images.githubusercontent.com/19958143/154537339-157ac8cc-63ea-40bb-8c29-7c55cce755c5.png">

but doesn't show up on `Community Rebrand` or `Original Community`, as the `alex_base` component overrides Discourse's default `suggested-topics` component, which normally renders the plugin outlet `Codecademy Related Content` uses.

Long story short, here's the fix! The change can be previewed live via the `Codecademy Community Theme Fork Staging` theme preview in Discourse. Let me know if you have any questions, and feel free to reach out to anyone else at the company to validate this change!

<img width="321" alt="Screen Shot 2022-02-17 at 1 33 23 PM" src="https://user-images.githubusercontent.com/19958143/154547731-47dafbb6-615c-404f-9c34-174fd4957984.png">